### PR TITLE
Update reseter.css

### DIFF
--- a/css/reseter.css
+++ b/css/reseter.css
@@ -601,10 +601,6 @@ dialog:not([open]) {
   opacity: 0.54;
 }
 
-input::placeholder {
-  opacity: 1;
-}
-
 [type=search] {
   outline-offset: -2px;
   -webkit-appearance: none;

--- a/css/reseter.css
+++ b/css/reseter.css
@@ -22,6 +22,7 @@
   }
 }
 
+input::placeholder { opacity: 1; }
 html,
 body,
 div,

--- a/css/reseter.css
+++ b/css/reseter.css
@@ -22,7 +22,6 @@
   }
 }
 
-input::placeholder { opacity: 1; }
 html,
 body,
 div,
@@ -600,6 +599,10 @@ dialog:not([open]) {
 ::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
+}
+
+input::placeholder {
+  opacity: 1;
 }
 
 [type=search] {

--- a/src/less/reseter.less
+++ b/src/less/reseter.less
@@ -611,3 +611,6 @@ template {
     position: absolute;
   }
 }
+input::placeholder {
+    opacity: 1;
+}

--- a/src/sass/reseter.sass
+++ b/src/sass/reseter.sass
@@ -519,6 +519,9 @@ dialog
   color: inherit
   opacity: 0.54
 
+input::placeholder
+    opacity: 1
+  
 [type="search"]
   outline-offset: -2px
   -webkit-appearance: none


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:
<!-- Replace "[ ]" with "[x]" to mark them as done --->

- [x] I followed the contributing guidelines: [https://github.com/krishdevdb/reseter.css/blob/master/contributing.md](https://github.com/krishdevdb/reseter.css/blob/master/contributing.md)

### Which change are you proposing?

  - [ ] Adding A New Element's Reset
  - [x] Editing A Old Element's Reset
  - [ ] Removing A Elements's Reset


> Write Something About It Here
works on the opacity of placeholder in input. (_pseudoelement_)
---------------------------------------------------------------------

My PR Meets The Following Criterias:
- [x] It Redifines Usefull Defaults (If you are doing it for h1 you redifine the font size to be big enough)
- [x] My Content Is Responsive If Applicable (If you are defining any `px` values please convert them to `rem` for responsiveness)
- [x] My Content Is Tested. That It Doesn't Breaks The Element
- [x] My Content Is Not My Personal Opinion
- [ ] I have used the command `yarn *:build`

<!-- Don't worry if you don't complete a source. our community will try best to make the changes in all sources as quick as possible -->
I've added the following sources:
- [ ] less
- [ ] scss
- [ ] sass
- [ ] stylus

> Fixes #16 Check #16
