### PR TITLE
Add 'acronym' selectors to existing 'abbr' selectors

### DIFF
--- a/src/less/reseter.less
+++ b/src/less/reseter.less
@@ -102,7 +102,9 @@ p {
   margin: 0 0 1rem;
 }
 abbr[title],
-abbr[data-bs-original-title] {
+abbr[data-bs-original-title],
+acronym[title],
+acronym[data-bs-original-title] {
   text-decoration: underline dotted;
   cursor: help;
   text-decoration-skip-ink: none;

--- a/src/sass/reseter.sass
+++ b/src/sass/reseter.sass
@@ -99,7 +99,9 @@ p
   margin: 0 0 1rem
 
 abbr[title],
-abbr[data-bs-original-title] 
+abbr[data-bs-original-title],
+acronym[title],
+acronym[data-bs-original-title]
   text-decoration: underline dotted
   cursor: help
   text-decoration-skip-ink: none

--- a/src/scss/reseter.scss
+++ b/src/scss/reseter.scss
@@ -102,7 +102,9 @@ p {
   margin: 0 0 1rem;
 }
 abbr[title],
-abbr[data-bs-original-title] {
+abbr[data-bs-original-title],
+acronym[title],
+acronym[data-bs-original-title] {
   text-decoration: underline dotted;
   cursor: help;
   text-decoration-skip-ink: none;

--- a/src/stylus/reseter.styl
+++ b/src/stylus/reseter.styl
@@ -97,7 +97,9 @@ p
   margin: 0 0 1rem
 
 abbr[title],
-abbr[data-bs-original-title] 
+abbr[data-bs-original-title],
+acronym[title],
+acronym[data-bs-original-title]
   text-decoration: underline dotted
   cursor: help
   text-decoration-skip-ink: none


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

<!-- Replace "[ ]" with "[x]" to mark them as done --->

- [X] I followed the contributing guidelines: [https://github.com/krishdevdb/reseter.css/blob/master/contributing.md](https://github.com/krishdevdb/reseter.css/blob/master/contributing.md)

### Which change are you proposing?

- [X] Adding A New Element's Reset
- [ ] Editing A Old Element's Reset
- [ ] Removing A Elements's Reset

> Write Something About It Here

Changed the `abbr` selector to select both `abbr`, `acronym`

My PR Meets The Following Criterias:

- [x] It Redifines Usefull Defaults (If you are doing it for h1 you redifine the font size to be big enough)
- [x] My Content Is Responsive If Applicable (If you are defining any `px` values please convert them to `rem` for responsiveness)
- [X] My Content Is Tested. That It Doesn't Breaks The Element
- [X] My Content Is Not My Personal Opinion
- [ ] I have used the command `yarn *:build`

<!-- Don't worry if you don't complete a source. our community will try best to make the changes in all sources as quick as possible -->

I've added the following sources:

- [X] less
- [X] scss
- [ ] sass
- [ ] stylus

> Please replace this line with an explanation of why you think these changes should be made.

In order to support the tags like `acronym`
