### PR TITLE
feat: add :focus-visible support for better keyboard accessibility

### DIFF
--- a/src/components/forms.scss
+++ b/src/components/forms.scss
@@ -90,3 +90,27 @@
 :-moz-ui-invalid {
   box-shadow: none;
 }
+
+/* Modern focus management for better accessibility */
+:where(
+  a,
+  button,
+  input,
+  select,
+  textarea,
+  [tabindex]:not([tabindex="-1"])
+):focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+/* Remove focus outline for mouse users */
+:where(
+  a,
+  button,
+  input,
+  select,
+  textarea
+):focus:not(:focus-visible) {
+  outline: none;
+}

--- a/src/components/forms.scss
+++ b/src/components/forms.scss
@@ -91,26 +91,21 @@
   box-shadow: none;
 }
 
-/* Modern focus management for better accessibility */
-:where(
-  a,
+:where(a,
   button,
   input,
   select,
   textarea,
-  [tabindex]:not([tabindex="-1"])
-):focus-visible {
+  [tabindex]:not([tabindex="-1"])):focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 2px;
 }
 
-/* Remove focus outline for mouse users */
-:where(
-  a,
+:where(a,
   button,
   input,
   select,
-  textarea
-):focus:not(:focus-visible) {
+  textarea,
+  [tabindex]:not([tabindex="-1"])):focus:not(:focus-visible) {
   outline: none;
 }


### PR DESCRIPTION
## Description
Adds `:focus-visible` CSS support for better keyboard accessibility.

## Changes
- Shows 2px outline for keyboard navigation (Tab)
- Hides outline for mouse clicks
- Uses `:where()` for low specificity
- Covers buttons, inputs, links, and other interactive elements

## Testing
✅ Built and tested in browser - keyboard shows outlines, mouse clicks don't

## Impact
- Improves keyboard accessibility
- Better WCAG 2.1 compliance
- No breaking changes
- 96%+ browser support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved focus styling for interactive elements to boost keyboard navigation visibility: added a clear, accessible focus outline for keyboard users while suppressing the outline for non-keyboard (mouse) interactions to reduce visual clutter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->