### PR TITLE
fix: update stale links from renamed repo and fix http URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable-next-line -->
-<div align="center"><img height="100px" width="100px" src="https://github.com/krshoss/gardevoir/raw/main/.github/assets/gardevoir.png"><br><h1>The Modern CSS Reset 🚀</h5></div>
+<div align="center"><img height="100px" width="100px" src="https://github.com/kkrishguptaa/reseter.css/raw/main/.github/assets/gardevoir.png"><br><h1>The Modern CSS Reset 🚀</h5></div>
 
 ## 🤓 Benefits
 
@@ -14,7 +14,7 @@
 
 There are many inconsistencies between browsers. Like Firefox 3 has a margin on top of paragraphs but Internet Explorer 7 doesn't have any margin. There are thousands of browsers with hundreds of versions. Each version at least has 500+ inconsistencies with different browsers' different versions. How to keep up? This is an easy to use solution called **Gardevoir**
 
-![Browser Inconsistencies](https://github.com/krshoss/gardevoir/raw/main/.github/assets/css_reset.png)
+![Browser Inconsistencies](https://github.com/kkrishguptaa/reseter.css/raw/main/.github/assets/css_reset.png)
 
 ## 🆚 There are other resets, why Gardevoir?
 
@@ -22,7 +22,7 @@ There are many inconsistencies between browsers. Like Firefox 3 has a margin on 
 | :-------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------: |
 |                   Normalizations                    |                                                         ✅                                                          |                                                           ✅                                                           |                                                          ✅                                                           |                                                          ❌                                                           |
 |               Basic elemental styles                |                                                         ✅                                                          |                                                        Partial                                                         |                                                          ✅                                                           |                                                          ❌                                                           |
-| Size (by [bundle phobia](http://bundlephobia.com/)) | Compile with Sass | ![GitHub file size in bytes](https://img.shields.io/github/size/necolas/normalize.css/normalize.css?style=flat-square) | ![GitHub file size in bytes](https://img.shields.io/github/size/csstools/sanitize.css/sanitize.css?style=flat-square) | ![GitHub file size in bytes](https://img.shields.io/github/size/shannonmoeller/reset-css/reset.css?style=flat-square) |
+| Size (by [bundle phobia](https://bundlephobia.com/)) | Compile with Sass | ![GitHub file size in bytes](https://img.shields.io/github/size/necolas/normalize.css/normalize.css?style=flat-square) | ![GitHub file size in bytes](https://img.shields.io/github/size/csstools/sanitize.css/sanitize.css?style=flat-square) | ![GitHub file size in bytes](https://img.shields.io/github/size/shannonmoeller/reset-css/reset.css?style=flat-square) |
 |                  Minified version                   |    Compile with Sass    |                                                  ❌ (Minify yourself)                                                  |                                                  ❌(Minify yourself)                                                  |                                                  ❌(Minify yourself)                                                  |     |
 |                     Box sizing                      |                                                         ✅                                                          |                                                           ❌                                                           |                                                          ✅                                                           |                                                          ❌                                                           |
 |                   Browser support                   |                                                    Customizable                                                     |                                                    Last 3 versions                                                     |                                                    Last 3 versions                                                    |                                                        Unknown                                                        |
@@ -58,7 +58,7 @@ There are many inconsistencies between browsers. Like Firefox 3 has a margin on 
 
 4. How about reading a guide for best performance? Here's the link to [optimizing Gardevoir for production](#-optimize)
 
-5. Lastly you can view [our wiki for best practices and performance guides](https://github.com/krshoss/gardevoir/wiki/Performance)
+5. Lastly you can view [our GitHub Discussions for best practices and performance guides](https://github.com/kkrishguptaa/reseter.css/discussions)
 
 6. 🥳 All Set Now
 


### PR DESCRIPTION
- Replace krshoss/gardevoir image URLs with current kkrishguptaa/reseter.css
- Fix bundlephobia link from http to https
- Replace broken wiki link with active GitHub Discussions page

Closes #135

## Related Issue

Closes: # <!-- issue number that will be closed through this PR -->

### Describe the changes you've made

<!-- Give a clear description of what modifications you have made -->

## How has this been tested?

<!-- Describe how have you verified the changes made -->

## Checklist

<!--
Example how to mark a checkbox:-
- [x] I have performed a self-review of my own code.
-->

- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have followed the code style of the project
- [ ] I have tested my code, and it works without errors

## Additional Information

<!-- Screenshots, notes for reviewers, anything? -->

## Code of Conduct

- [ ] I agree to follow this project's [Code of Conduct](https://github.com/krshoss/gardevoir/blob/main/CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed project branding and logos
  * Updated external resource links and screenshots
  * Migrated best practices and performance guides to GitHub Discussions for centralized community access
  * Enhanced security by updating external references to HTTPS protocol

<!-- end of auto-generated comment: release notes by coderabbit.ai -->